### PR TITLE
Validación de un catálogo entero

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arrow
 pandas
 python-dateutil
-pydatajson>=0.4.34
+pydatajson>=0.4.40
 six

--- a/series_tiempo_ar/core.py
+++ b/series_tiempo_ar/core.py
@@ -22,6 +22,7 @@ from __future__ import with_statement
 
 from pydatajson import DataJson
 
+from series_tiempo_ar.time_series_validator import TimeSeriesValidator
 from .paths import SCHEMAS_DIR
 from . import readers
 
@@ -32,7 +33,12 @@ class TimeSeriesDataJson(DataJson):
     """Métodos para trabajar con catálogos de series de tiempo en data.json."""
 
     def __init__(
-        self, catalog=None, schema_filename=None, schema_dir=None, default_values=None
+        self,
+        catalog=None,
+        schema_filename=None,
+        schema_dir=None,
+        default_values=None,
+        validator_class=TimeSeriesValidator,
     ):
         schema_filename = schema_filename or DEFAULT_CATALOG_SCHEMA_FILENAME
         schema_dir = schema_dir or SCHEMAS_DIR
@@ -42,6 +48,7 @@ class TimeSeriesDataJson(DataJson):
             schema_filename=schema_filename,
             schema_dir=schema_dir,
             default_values=default_values,
+            validator_class=validator_class,
         )
 
         self.generate_distribution_ids()

--- a/series_tiempo_ar/custom_exceptions.py
+++ b/series_tiempo_ar/custom_exceptions.py
@@ -8,7 +8,17 @@ from __future__ import print_function
 from __future__ import with_statement
 
 
-class InvalidNumericField(ValueError):
+class TimeSeriesError(ValueError):
+    def __init__(self, *args):
+        super(TimeSeriesError, self).__init__(*args)
+        self.message = args[0]
+        self.validator = "time_series_format"
+        self.path = []
+        self.validator_value = None
+        self.instance = None
+
+
+class InvalidNumericField(TimeSeriesError):
     def __init__(self, field_title, values):
         msg = "'{}' tiene valores no numericos: '{}'".format(
             field_title, " ".join(list(values))
@@ -16,7 +26,7 @@ class InvalidNumericField(ValueError):
         super(InvalidNumericField, self).__init__(msg)
 
 
-class FieldTitleTooLongError(ValueError):
+class FieldTitleTooLongError(TimeSeriesError):
     def __init__(self, field, field_len, max_field_len):
         msg = "'{}' tiene '{}' caracteres. Maximo: '{}'".format(
             field, field_len, max_field_len
@@ -24,7 +34,7 @@ class FieldTitleTooLongError(ValueError):
         super(FieldTitleTooLongError, self).__init__(msg)
 
 
-class InvalidFieldTitleError(ValueError):
+class InvalidFieldTitleError(TimeSeriesError):
     def __init__(self, field, char=None, valid_field_chars=None, is_unnamed=None):
         if is_unnamed:
             msg = "Existe un campo sin nombre en la distribucion: '{}'"
@@ -39,7 +49,7 @@ class InvalidFieldTitleError(ValueError):
         super(InvalidFieldTitleError, self).__init__(msg)
 
 
-class InvalidFieldIdError(ValueError):
+class InvalidFieldIdError(TimeSeriesError):
     def __init__(self, field_id, char, valid_field_chars):
         msg = "'{}' usa caracteres invalidos ('{}'). Validos: '{}'".format(
             field_id, char, valid_field_chars
@@ -47,13 +57,13 @@ class InvalidFieldIdError(ValueError):
         super(InvalidFieldIdError, self).__init__(msg)
 
 
-class TimeIndexFutureTimeValueError(ValueError):
+class TimeIndexFutureTimeValueError(TimeSeriesError):
     def __init__(self, iso_time_value, iso_now):
         msg = "{} es fecha futura respecto de {}".format(iso_time_value, iso_now)
         super(TimeIndexFutureTimeValueError, self).__init__(msg)
 
 
-class FieldFewValuesError(ValueError):
+class FieldFewValuesError(TimeSeriesError):
     def __init__(self, field, positive_values, minimum_values):
         msg = "{} tiene {} valores, deberia tener {} o mas".format(
             field, positive_values, minimum_values
@@ -61,7 +71,7 @@ class FieldFewValuesError(ValueError):
         super(FieldFewValuesError, self).__init__(msg)
 
 
-class FieldTooManyMissingsError(ValueError):
+class FieldTooManyMissingsError(TimeSeriesError):
     def __init__(self, field, missing_values, positive_values):
         msg = "{} tiene mas missings ({}) que valores ({})".format(
             field, missing_values, positive_values
@@ -69,13 +79,13 @@ class FieldTooManyMissingsError(ValueError):
         super(FieldTooManyMissingsError, self).__init__(msg)
 
 
-class DatasetTemporalMetadataError(ValueError):
+class DatasetTemporalMetadataError(TimeSeriesError):
     def __init__(self, temporal):
         msg = "{} no es un formato de 'temporal' valido".format(temporal)
         super(DatasetTemporalMetadataError, self).__init__(msg)
 
 
-class TimeValueBeforeTemporalError(ValueError):
+class TimeValueBeforeTemporalError(TimeSeriesError):
     def __init__(self, iso_time_value, iso_ini_temporal):
         msg = "Serie comienza ({}) antes de 'temporal' ({}) ".format(
             iso_time_value, iso_ini_temporal
@@ -83,7 +93,7 @@ class TimeValueBeforeTemporalError(ValueError):
         super(TimeValueBeforeTemporalError, self).__init__(msg)
 
 
-class TimeIndexTooShortError(ValueError):
+class TimeIndexTooShortError(TimeSeriesError):
     def __init__(self, iso_end_index, iso_half_temporal, temporal):
         msg = "Serie termina ({}) antes de mitad de 'temporal' ({}) {}".format(
             iso_end_index, iso_half_temporal, temporal
@@ -91,7 +101,7 @@ class TimeIndexTooShortError(ValueError):
         super(TimeIndexTooShortError, self).__init__(msg)
 
 
-class BaseRepetitionError(ValueError):
+class BaseRepetitionError(TimeSeriesError):
 
     """El id de una entidad está repetido en el catálogo."""
 
@@ -145,7 +155,7 @@ class DatasetIdRepetitionError(BaseRepetitionError):
         super(DatasetIdRepetitionError, self).__init__(msg)
 
 
-class BaseNonExistentError(ValueError):
+class BaseNonExistentError(TimeSeriesError):
     @staticmethod
     def get_msg(entity_name, entity_type, entity_id):
         """El id de una entidad no existe en el catálogo."""
@@ -176,13 +186,13 @@ class DatasetIdNonExistentError(BaseNonExistentError):
         super(DatasetIdNonExistentError, self).__init__(msg)
 
 
-class FieldMissingInDistrbutionError(ValueError):
+class FieldMissingInDistrbutionError(TimeSeriesError):
     def __init__(self, field, distribution):
         msg = "Campo {} faltante en la distribución {}".format(field, distribution)
         super(FieldMissingInDistrbutionError, self).__init__(msg)
 
 
-class DistributionBadDataError(ValueError):
+class DistributionBadDataError(TimeSeriesError):
     def __init__(
         self,
         distribution_id,
@@ -207,7 +217,7 @@ class DistributionBadDataError(ValueError):
         super(DistributionBadDataError, self).__init__(msg)
 
 
-class HeaderNotBlankOrIdError(ValueError):
+class HeaderNotBlankOrIdError(TimeSeriesError):
     def __init__(self, worksheet, header_coord, header_value, ws_header_value):
         msg = "'{}' en hoja '{}' tiene '{}'. Debe ser vacio o '{}'".format(
             header_coord, worksheet, ws_header_value, header_value
@@ -215,7 +225,7 @@ class HeaderNotBlankOrIdError(ValueError):
         super(HeaderNotBlankOrIdError, self).__init__(msg)
 
 
-class HeaderIdError(ValueError):
+class HeaderIdError(TimeSeriesError):
     def __init__(self, worksheet, header_coord, header_value, ws_header_value):
         msg = "'{}' en hoja '{}' tiene '{}'. Debe ser '{}'".format(
             header_coord, worksheet, ws_header_value, header_value
@@ -223,7 +233,7 @@ class HeaderIdError(ValueError):
         super(HeaderIdError, self).__init__(msg)
 
 
-class ScrapingStartCellsIdenticalError(ValueError):
+class ScrapingStartCellsIdenticalError(TimeSeriesError):
     def __init__(self, scrapingIdentifierCell, scrapingDataStartCell):
         msg = "scrapingIdentifierCell ({}) es igual a scrapingDataStartCell ({})".format(
             scrapingIdentifierCell, scrapingDataStartCell
@@ -231,7 +241,7 @@ class ScrapingStartCellsIdenticalError(ValueError):
         super(ScrapingStartCellsIdenticalError, self).__init__(msg)
 
 
-class DistributionTooManyNullSeriesError(Exception):
+class DistributionTooManyNullSeriesError(TimeSeriesError):
     def __init__(self, distribution, max_allowed_proportion, null_proportion):
         msg = "Proporción de series nulas en distribución {} por encima del umbral permitido ({}): {}".format(
             distribution, max_allowed_proportion, null_proportion
@@ -239,7 +249,7 @@ class DistributionTooManyNullSeriesError(Exception):
         super(DistributionTooManyNullSeriesError, self).__init__(msg)
 
 
-class NonExistentDescriptionError(Exception):
+class NonExistentDescriptionError(TimeSeriesError):
     def __init__(self, distribution_id):
         msg = "Existen fields sin descripción en la distribución {}".format(
             distribution_id

--- a/series_tiempo_ar/time_series_validator.py
+++ b/series_tiempo_ar/time_series_validator.py
@@ -1,0 +1,11 @@
+from pydatajson.validation import Validator
+
+from series_tiempo_ar.validations import get_distribution_errors
+
+
+class TimeSeriesValidator(Validator):
+    def _custom_errors(self, catalog):
+        yield from super(TimeSeriesValidator, self)._custom_errors(catalog)
+
+        for distribution in catalog.get_distributions(only_time_series=True):
+            yield from get_distribution_errors(catalog, distribution.get("identifier"))

--- a/series_tiempo_ar/validations/validators.py
+++ b/series_tiempo_ar/validations/validators.py
@@ -5,7 +5,7 @@
 
 # pylint: disable=W0614
 # pylint: disable=W0401
-
+from series_tiempo_ar.custom_exceptions import TimeSeriesError
 from series_tiempo_ar.validations.xlsx_validations import *
 from . import csv_validations
 
@@ -37,7 +37,7 @@ def get_distribution_errors(catalog, distribution_id):
     for validation in CSV_VALIDATIONS:
         try:
             validation(df, distribution, catalog)
-        except Exception as e:
+        except TimeSeriesError as e:
             errors.append(e)
 
     return errors

--- a/tests/samples/missing_dataset_title.json
+++ b/tests/samples/missing_dataset_title.json
@@ -1,4 +1,19 @@
 {
+  "modified": "2017-09-28",
+  "issued": "2017-09-28",
+  "title": "Datos Programación Macroeconómica",
+  "spatial": "ARG",
+  "language": [
+    "SPA"
+  ],
+  "rights": "2017-09-28",
+  "license": "Creative Commons Attribution 4.0",
+  "description": "Catálogo de datos abiertos de la Subsecretaría de Programación Macroeconómica.",
+  "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+  "publisher": {
+    "mbox": "datoseconomicos@mecon.gov.ar",
+    "name": "Subsecretaría de Programación Macroeconómica."
+  },
   "dataset": [
     {
       "publisher": {
@@ -10,7 +25,6 @@
       "superTheme": [
         "ECON"
       ],
-      "title": "Índice de Precios Internos Básicos al por Mayor (IPIB) hasta cuatro dígitos",
       "language": [
         "SPA"
       ],
@@ -69,13 +83,13 @@
             },
             {
               "distribution_identifier": "125.1",
-              "description": "Descripción de la serie 1",
+              "description": "Descripción de la serie 2",
               "title": "title2",
               "dataset_identifier": "125",
               "scrapingIdentifierCell": "DS8",
               "units": "Índice 1993=100",
               "type": "number",
-              "id": "id_serie_1",
+              "id": "id_serie_2",
               "scrapingDataStartCell": "DS9"
             }
           ],

--- a/tests/samples/missing_field_description.json
+++ b/tests/samples/missing_field_description.json
@@ -42,7 +42,7 @@
           "issued": "2017-09-28T00:00:00",
           "title": "Distribución ejemplo",
           "modified": "2017-09-28T00:00:00",
-          "fileName": "Índice-precios-internos-basicos-al-por-mayor-desagregado-base-1993-anual.csv",
+          "fileName": "indice-precios-internos-basicos-al-por-mayor-desagregado-base-1993-anual.csv",
           "downloadURL": "http://localhost:3456/tests/samples/sample_data.csv",
           "field": [
             {

--- a/tests/samples/missing_field_identifier.json
+++ b/tests/samples/missing_field_identifier.json
@@ -1,0 +1,103 @@
+{
+  "modified": "2017-09-28",
+  "issued": "2017-09-28",
+  "title": "Datos Programación Macroeconómica",
+  "spatial": "ARG",
+  "language": [
+    "SPA"
+  ],
+  "rights": "2017-09-28",
+  "license": "Creative Commons Attribution 4.0",
+  "description": "Catálogo de datos abiertos de la Subsecretaría de Programación Macroeconómica.",
+  "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+  "publisher": {
+    "mbox": "datoseconomicos@mecon.gov.ar",
+    "name": "Subsecretaría de Programación Macroeconómica."
+  },
+  "dataset": [
+    {
+      "publisher": {
+        "mbox": "ausolari@mecon.gob.ar",
+        "name": "Ministerio de Hacienda. Secretaría de Política Económica. Subsecretaría de Programación Macroeconómica."
+      },
+      "landingPage": "https://www.minhacienda.gob.ar/secretarias/politica-economica/programacion-macroeconomica/",
+      "description": "Índice de Precios Internos Básicos al por Mayor (IPIB) desagregado hasta cuatro dígitos (base 1993)",
+      "superTheme": [
+        "ECON"
+      ],
+      "title": "Índice de Precios Internos Básicos al por Mayor (IPIB) hasta cuatro dígitos",
+      "language": [
+        "SPA"
+      ],
+      "issued": "2017-09-28T00:00:00",
+      "temporal": "1993-01-01/2015-10-31",
+      "modified": "2017-09-28T00:00:00",
+      "source": "Instituto Nacional de Estadística y Censos (INDEC)",
+      "theme": [
+        "Índice de Precios Interno al por mayor"
+      ],
+      "keyword": [
+        "Información económica al día",
+        "precio"
+      ],
+      "accrualPeriodicity": "R/P1M",
+      "spatial": "ARG",
+      "identifier": "125",
+      "contactPoint": {
+        "fn": "Ministerio de Hacienda. Secretaría de Política Económica. Subsecretaría de Programación Macroeconómica. Dirección de Información y Coyuntura"
+      },
+      "accessLevel": "ABIERTO",
+      "distribution": [
+        {
+          "accessURL": "https://www.minhacienda.gob.ar/secretarias/politica-economica/programacion-macroeconomica/",
+          "scrapingFileSheet": "4.12",
+          "description": "Distribución de ejemplo para testing",
+          "format": "CSV",
+          "dataset_identifier": "125",
+          "issued": "2017-09-28T00:00:00",
+          "title": "Distribución ejemplo",
+          "modified": "2017-09-28T00:00:00",
+          "fileName": "indice-precios-internos-basicos-al-por-mayor-desagregado-base-1993-anual.csv",
+          "downloadURL": "http://localhost:3456/tests/samples/sample_data.csv",
+          "field": [
+            {
+              "distribution_identifier": "125.1",
+              "title": "indice_tiempo",
+              "dataset_identifier": "125",
+              "scrapingIdentifierCell": "A8",
+              "specialTypeDetail": "R/P1M",
+              "specialType": "time_index",
+              "type": "date",
+              "id": "time_index",
+              "scrapingDataStartCell": "A9"
+            },
+            {
+              "distribution_identifier": "125.1",
+              "description": "Descripción de la serie 1",
+              "title": "title1",
+              "dataset_identifier": "125",
+              "scrapingIdentifierCell": "DS8",
+              "units": "Índice 1993=100",
+              "type": "number",
+              "scrapingDataStartCell": "DS9"
+            },
+            {
+              "distribution_identifier": "125.1",
+              "description": "Descripción de la serie 2",
+              "title": "title2",
+              "dataset_identifier": "125",
+              "scrapingIdentifierCell": "DS8",
+              "units": "Índice 1993=100",
+              "type": "number",
+              "scrapingDataStartCell": "DS9"
+            }
+          ],
+          "draft": false,
+          "units": "Índice",
+          "identifier": "125.1",
+          "scrapingFileURL": "https://www.economia.gob.ar/download/infoeco/apendice4.xlsx"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/samples/repeated_field_id.json
+++ b/tests/samples/repeated_field_id.json
@@ -57,7 +57,7 @@
           "issued": "2017-09-28T00:00:00",
           "title": "Distribución ejemplo",
           "modified": "2017-09-28T00:00:00",
-          "fileName": "Índice-precios-internos-basicos-al-por-mayor-desagregado-base-1993-anual.csv",
+          "fileName": "indice-precios-internos-basicos-al-por-mayor-desagregado-base-1993-anual.csv",
           "downloadURL": "http://localhost:3456/tests/samples/sample_data.csv",
           "field": [
             {

--- a/tests/samples/valid_catalog.json
+++ b/tests/samples/valid_catalog.json
@@ -1,4 +1,19 @@
 {
+  "modified": "2017-09-28",
+  "issued": "2017-09-28",
+  "title": "Datos Programación Macroeconómica",
+  "spatial": "ARG",
+  "language": [
+    "SPA"
+  ],
+  "rights": "2017-09-28",
+  "license": "Creative Commons Attribution 4.0",
+  "description": "Catálogo de datos abiertos de la Subsecretaría de Programación Macroeconómica.",
+  "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+  "publisher": {
+    "mbox": "datoseconomicos@mecon.gov.ar",
+    "name": "Subsecretaría de Programación Macroeconómica."
+  },
   "dataset": [
     {
       "publisher": {
@@ -69,13 +84,13 @@
             },
             {
               "distribution_identifier": "125.1",
-              "description": "Descripción de la serie 1",
+              "description": "Descripción de la serie 2",
               "title": "title2",
               "dataset_identifier": "125",
               "scrapingIdentifierCell": "DS8",
               "units": "Índice 1993=100",
               "type": "number",
-              "id": "id_serie_1",
+              "id": "id_serie_2",
               "scrapingDataStartCell": "DS9"
             }
           ],

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -21,3 +21,9 @@ class ValidationsTests(TestCase):
         validation = catalog.validate_catalog()
 
         self.assertEqual(validation["status"], "ERROR")
+
+    def test_missing_field_identifier(self):
+        catalog = read_data_json("missing_dataset_title.json")
+        validation = catalog.validate_catalog()
+
+        self.assertEqual(validation["status"], "ERROR")

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+
+from tests.helpers import read_data_json
+
+
+class ValidationsTests(TestCase):
+    def test_valid_catalog(self):
+        catalog = read_data_json("valid_catalog.json")
+        validation = catalog.validate_catalog()
+
+        self.assertEqual(validation["status"], "OK")
+
+    def test_invalid_catalog(self):
+        catalog = read_data_json("repeated_field_id.json")
+        validation = catalog.validate_catalog()
+
+        self.assertEqual(validation["status"], "ERROR")
+
+    def test_invalid_format_catalog(self):
+        catalog = read_data_json("missing_dataset_title.json")
+        validation = catalog.validate_catalog()
+
+        self.assertEqual(validation["status"], "ERROR")


### PR DESCRIPTION
Se implementa un validador _custom_ para `TimeSeriesDataJson`, con las validaciones de distribuciones de series de tiempo. El método `validate_catalog` termina devolviendo estos errores, por ahora a nivel catálogo.